### PR TITLE
Fixed StrEffect texture animation.

### DIFF
--- a/src/Loaders/Str.js
+++ b/src/Loaders/Str.js
@@ -103,7 +103,7 @@ define( ['Utils/BinaryReader'], function( BinaryReader )
 		this.xy        = new Float32Array([ fp.readFloat(), fp.readFloat(), fp.readFloat(), fp.readFloat(), fp.readFloat(), fp.readFloat(), fp.readFloat(), fp.readFloat() ]);
 		this.aniframe  = fp.readFloat();
 		this.anitype   = fp.readULong();
-		this.delay     = fp.readFloat() * 1000;
+		this.delay     = fp.readFloat();
 		this.angle     = fp.readFloat() / (1024/360);
 		this.color     = new Float32Array([ fp.readFloat() / 255.0, fp.readFloat() / 255.0, fp.readFloat() / 255.0, fp.readFloat() / 255.0 ]);
 		this.srcalpha  = fp.readULong();

--- a/src/Renderer/StrEffect.js
+++ b/src/Renderer/StrEffect.js
@@ -382,21 +382,21 @@ define(['Utils/WebGL', 'Utils/gl-matrix', 'Core/Client'], function( WebGL, glMat
 				break;
 
 			case 1: // normal
-				result.aniframe = from.aniframe + to.aniframe * delta;
+				result.aniframe = from.aniframe + to.delay * delta;
 				break;
 
 			case 2: // Stop at end
-				result.aniframe = from.aniframe + to.aniframe * Math.min(delta, 1.0);
+				result.aniframe = Math.min(from.aniframe + to.delay * delta, layer.texcnt - 1);
 				break;
 
 			case 3: // Repeat
-				result.aniframe = from.aniframe + to.aniframe * (delta % 1.0);
+				result.aniframe = (from.aniframe + to.delay * delta) % layer.texcnt;
 				break;
 
 			case 4: // play reverse infinitly
-				result.aniframe = from.aniframe - to.aniframe * (delta % 1.0);
+				result.aniframe = (from.aniframe - to.delay * delta) % layer.texcnt;
 				break;
-		}
+		}		
 
 		return true;
 	}


### PR DESCRIPTION
The result.aniframe contains a float number but it refers to the current texture index from the layer.texname array. When doing interpolation in calculateAnimation you need to increase the aniframe by to.delay \* delta, so it increases slowly and when it reaches the next integer, a new texture frame will be displayed. This means that the maximum valid value for aniframe is layer.texcnt-1. 

Also the STRAnimation.delay property should not be multiplied by 1000, so I removed that.

To test the effects try: 
thunderstorm.str
jong_mini.str
