### PR TITLE
Bugfix #58 - ReferenceError in firefox

### DIFF
--- a/src/UI/Components/Emoticons/Emoticons.js
+++ b/src/UI/Components/Emoticons/Emoticons.js
@@ -225,7 +225,7 @@ define(function(require)
 	/**
 	 * Exit window
 	 */
-	function onClose()
+	function onClose( event )
 	{
 		Emoticons.ui.hide();
 


### PR DESCRIPTION
Fixes #58 for Firefox as it doesn't have a global `event` object.
