### PR TITLE
Removed X-Application headers

### DIFF
--- a/client/index.php
+++ b/client/index.php
@@ -10,10 +10,7 @@
 
 	// Apply configs
 	if ($CONFIGS['DEBUG']) {
-		// Do not show debug if the request is from roBrowser
-		if (empty($_SERVER['HTTP_X_APPLICATION']) || $_SERVER['HTTP_X_APPLICATION'] !== 'roBrowser') {
-			Debug::enable();
-		}
+		Debug::enable();
 	}
 
 

--- a/src/Core/FileManager.js
+++ b/src/Core/FileManager.js
@@ -167,7 +167,6 @@ define(function( require )
 			var req    = new XMLHttpRequest();
 			req.open('POST', this.remoteClient, false);
 			req.setRequestHeader('Content-type','application/x-www-form-urlencoded');
-			req.setRequestHeader('X-Application', 'roBrowser');
 			req.overrideMimeType('text/plain; charset=ISO-8859-1');
 			req.send('filter=' + encodeURIComponent(regex.source));
 			return req.responseText.split('\n');
@@ -268,7 +267,6 @@ define(function( require )
 
 		var xhr = new XMLHttpRequest();
 		xhr.open('GET', this.remoteClient + filename, true);
-		xhr.setRequestHeader('X-Application', 'roBrowser');
 		xhr.responseType = 'arraybuffer';
 		xhr.onload = function(){
 			if (xhr.status == 200) {


### PR DESCRIPTION
When using XHR w/ CORS, any custom header can trigger preflight
requests. Removing this header avoided tons of preflight requests, when
loading from the remoteClient.
