### PR TITLE
Updated README with grammar/spelling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ If you don't run roBrowser in a Chrome App, you will need a Java plugin installe
 1.  [Download roBrowser](https://github.com/vthibault/roBrowser/archive/master.zip) and extract it.
 2.  [Convert DB](https://github.com/vthibault/roBrowser/tree/master/tools/converter/) to get custom content to roBrowser.
 3.  [Compile scripts](https://github.com/vthibault/roBrowser/tree/master/tools/build/) to reduce loading time.
-4.  Installing the [remote client](https://github.com/vthibault/roBrowser/tree/master/client) and set the parameter *remoteClient* to your server
-5.  Installing the [websocket proxy](https://github.com/herenow/wsProxy/blob/master/README.md) and set the parameter *socketProxy* to your proxy server url
+4.  Install the [remote client](https://github.com/vthibault/roBrowser/tree/master/client) and set the parameter *remoteClient* to your server.
+5.  Install the [websocket proxy](https://github.com/herenow/wsProxy/blob/master/README.md) and set the parameter *socketProxy* to your proxy server URL.
 6.  Configure roBrowser - [documentation](http://www.robrowser.com/getting-started#API) and some [examples](https://github.com/vthibault/roBrowser/tree/master/examples)
 
 ## Contributing


### PR DESCRIPTION
-Changed the verb tense of 'install' to the present tense since the document is in present tense
-Added a period to the end of the two sentences in Quickstart so it can be consistent with the other ones
-URL is an abbreviation that should always be capitalized
