### PR TITLE
Fix #110, moved queryUsageAndQuota from worker thread

### DIFF
--- a/src/Core/Client.js
+++ b/src/Core/Client.js
@@ -145,12 +145,16 @@ define(function( require )
 
 		// Get temporary storage info at main thread, the worker can't access it.
 		// https://github.com/vthibault/roBrowser/issues/110
-		temporaryStorage = navigator.temporaryStorage || navigator.webkitTemporaryStorage;
+		temporaryStorage = navigator.temporaryStorage || navigator.webkitTemporaryStorage || {
+			queryUsageAndQuota: function(callback) {
+				callback(0, 0);
+			}
+		};
 
 		temporaryStorage.queryUsageAndQuota(function(used, remaining) {
 			var quota = {
 				used: used,
-			remaining: remaining
+				remaining: remaining
 			};
 
 			// Initialize client files (load GRF, etc).

--- a/src/Core/Client.js
+++ b/src/Core/Client.js
@@ -79,6 +79,7 @@ define(function( require )
 		var last_tick   = Date.now();
 		var list        = [];
 		var i, count;
+		var temporaryStorage;
 
 		if (files.length) {
 			// Progressbar
@@ -142,12 +143,24 @@ define(function( require )
 			}
 		}
 
-		// Initialize client files (load GRF, etc).
-		Thread.send( 'CLIENT_INIT', {
-			files:     list,
-			grfList:   Configs.get('grfList') || 'DATA.INI',
-			save:    !!Configs.get('saveFiles')
-		}, Client.onFilesLoaded );
+		// Get temporary storage info at main thread, the worker can't access it.
+		// https://github.com/vthibault/roBrowser/issues/110
+		temporaryStorage = navigator.temporaryStorage || navigator.webkitTemporaryStorage;
+
+		temporaryStorage.queryUsageAndQuota(function(used, remaining) {
+			var quota = {
+				used: used,
+			remaining: remaining
+			};
+
+			// Initialize client files (load GRF, etc).
+			Thread.send( 'CLIENT_INIT', {
+				files:     list,
+				grfList:   Configs.get('grfList') || 'DATA.INI',
+				save:    !!Configs.get('saveFiles'),
+				quota:     quota
+			}, Client.onFilesLoaded );
+		});
 	}
 
 

--- a/src/Core/FileSystem.js
+++ b/src/Core/FileSystem.js
@@ -67,8 +67,9 @@ define(function()
 	 *
 	 * @param {Array} FileList
 	 * @param {boolean} save files
+	 * @param {Object} quota information
 	 */
-	function init( files, save )
+	function init( files, save, quota )
 	{
 		var requestFileSystemSync, requestFileSystem, temporaryStorage;
 		_files = normalizeFilesPath(files);
@@ -82,26 +83,22 @@ define(function()
 
 		requestFileSystemSync = self.requestFileSystemSync || self.webkitRequestFileSystemSync;
 		requestFileSystem     = self.requestFileSystem     || self.webkitRequestFileSystem;
-		temporaryStorage      = navigator.temporaryStorage || navigator.webkitTemporaryStorage;
 
-		temporaryStorage.queryUsageAndQuota(function(used, remaining){
-			var size = _clientSize || used || remaining;
+		var size = _clientSize || quota.used || quota.remaining;
 
-			requestFileSystem( self.TEMPORARY, size, function( fs ){
-				_fs      = fs;
-				_fs_sync = requestFileSystemSync( self.TEMPORARY, size );
+		requestFileSystem( self.TEMPORARY, size, function( fs ){
+			_fs      = fs;
+			_fs_sync = requestFileSystemSync( self.TEMPORARY, size );
 
-				if (save && _files.length) {
-					cleanUp();
-					buildHierarchy();
-					processUpload(0);
-				}
+			if (save && _files.length) {
+				cleanUp();
+				buildHierarchy();
+				processUpload(0);
+			}
 
-				_save = save;
-				trigger('onready');
-			}, errorHandler);
-
-		});
+			_save = save;
+			trigger('onready');
+		}, errorHandler);
 	}
 
 

--- a/src/Core/ThreadEventHandler.js
+++ b/src/Core/ThreadEventHandler.js
@@ -93,7 +93,7 @@ function(      FileManager,        FileSystem,           MapLoader )
 				});
 
 				// Saving full client
-				FileSystem.init( msg.data.files, msg.data.save );
+				FileSystem.init( msg.data.files, msg.data.save, msg.data.quota );
 				break;
 
 			// Files alias


### PR DESCRIPTION
In newer version of chrome >= 40.0.22x `navigator.webkitTemporaryStorage` is not available anymore in the worker thread context.